### PR TITLE
Update README for 2020 scheduling change

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 SFNode Contribute
 =================
-We meet on the first Thursday of every month. Join us!
+We meet on the second Thursday of every month. Join us!
 
 [Propose a topic, talk, speaker, or location for SFNode.](https://github.com/sfnode/sfnode/issues)
 


### PR DESCRIPTION
The meetup page has a schedule update saying that SFNode is now meeting on the second Thursday of each month, so this updates the README to reflect that.