### PR TITLE
fix: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/something-else.yml
+++ b/.github/ISSUE_TEMPLATE/something-else.yml
@@ -1,5 +1,5 @@
 name: Something else
-about: Need to open an issue that's not about Talks or Venues?
+description: Need to open an issue that's not about Talks or Venues?
 assignees:
   - 'Zahidul-Islam'
   - 'christian-bromann'

--- a/.github/ISSUE_TEMPLATE/talk-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.yml
@@ -1,5 +1,4 @@
 name: Talk Proposal
-about: Describe this issue template's purpose here.
 title: 'Talk Proposal: {Talk Title}'
 labels: 'talk'
 assignees:

--- a/.github/ISSUE_TEMPLATE/talk-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.yml
@@ -1,6 +1,6 @@
 name: Talk Proposal
 title: 'Talk Proposal: {Talk Title}'
-description: Propose a talk for a future SFNode event
+description: Want to give a talk at a future SFNode event?
 labels: 'talk'
 assignees:
   - 'Zahidul-Islam'

--- a/.github/ISSUE_TEMPLATE/talk-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/talk-proposal.yml
@@ -1,5 +1,6 @@
 name: Talk Proposal
 title: 'Talk Proposal: {Talk Title}'
+description: Propose a talk for a future SFNode event
 labels: 'talk'
 assignees:
   - 'Zahidul-Islam'

--- a/.github/ISSUE_TEMPLATE/venue-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/venue-proposal.yml
@@ -1,5 +1,5 @@
 name: Venue Proposal
-about: Have a location that would be ideal for hosting SF Node?
+description: Have a location that would be ideal for hosting SF Node?
 title: 'Venue Proposal: {Company/Organization Name}'
 labels: 'host'
 assignees:


### PR DESCRIPTION
Looks like GitHub changed the way it parses `ISSUE_TEMPLATE/*.yml` files, so the templates aren't valid anymore in this repo.

Apologies for formatting as a bunch of little commits instead of one big one, I applied these changes through the GitHub UI 😅